### PR TITLE
Account wrapper does not guard against using environment in naming

### DIFF
--- a/API.md
+++ b/API.md
@@ -2482,6 +2482,7 @@ new EnvironmentContext()
 | <code><a href="#@alma-cdk/project.EnvironmentContext.isFeature">isFeature</a></code> | Check if Environment is part of `feature` category. |
 | <code><a href="#@alma-cdk/project.EnvironmentContext.isMock">isMock</a></code> | Check if Environment is part of `mock` category. |
 | <code><a href="#@alma-cdk/project.EnvironmentContext.isStable">isStable</a></code> | Check if Environment is part of `stable` category. |
+| <code><a href="#@alma-cdk/project.EnvironmentContext.isValid">isValid</a></code> | Does the scope specify a valid environment. |
 | <code><a href="#@alma-cdk/project.EnvironmentContext.isVerification">isVerification</a></code> | Check if Environment is part of `verification` category. |
 
 ---
@@ -2728,6 +2729,22 @@ Returns `true` for `staging` & `production`, otherwise `false`.
 - *Type:* constructs.Construct
 
 Construct.
+
+---
+
+##### `isValid` <a name="isValid" id="@alma-cdk/project.EnvironmentContext.isValid"></a>
+
+```typescript
+import { EnvironmentContext } from '@alma-cdk/project'
+
+EnvironmentContext.isValid(scope: Construct)
+```
+
+Does the scope specify a valid environment.
+
+###### `scope`<sup>Required</sup> <a name="scope" id="@alma-cdk/project.EnvironmentContext.isValid.parameter.scope"></a>
+
+- *Type:* constructs.Construct
 
 ---
 

--- a/src/context/environment.test.ts
+++ b/src/context/environment.test.ts
@@ -1,0 +1,60 @@
+import { EnvironmentContext } from '.';
+import { AccountStrategy } from '../configurations';
+import { Project, ProjectProps } from '../project';
+
+const projectProps: ProjectProps = {
+  name: 'test-project',
+  author: {
+    organization: 'Acme',
+    name: 'Test Author',
+    email: 'test@example.com',
+  },
+  accounts: AccountStrategy.one({
+    shared: {
+      id: '123456789012',
+    },
+  }),
+};
+
+describe('EnvironmentContext', () => {
+
+  test('Environment test is valid', () => {
+    const project = new Project({
+      ...projectProps,
+      context: {
+        account: 'shared',
+        environment: 'test',
+      },
+    });
+
+    expect(EnvironmentContext.isValid(project)).toBeTruthy();
+
+  });
+
+  test('Environment dilledong is invalid', () => {
+    const project = new Project({
+      ...projectProps,
+      context: {
+        account: 'shared',
+        environment: 'dilledong',
+      },
+    });
+
+    expect(EnvironmentContext.isValid(project)).toBeFalsy();
+
+  });
+
+
+  test('Undefined environment is invalid', () => {
+    const project = new Project({
+      ...projectProps,
+      context: {
+        account: 'shared',
+      },
+    });
+
+    expect(EnvironmentContext.isValid(project)).toBeFalsy();
+
+  });
+
+});

--- a/src/context/environment.ts
+++ b/src/context/environment.ts
@@ -179,9 +179,21 @@ export class EnvironmentContext {
     return name.replace(/^feature\//i, '');
   }
 
+  /**
+   * Does the scope specify a valid environment
+   * @param {Construct} scope
+   * @returns true if valid, false otherwise
+   */
+  static isValid (scope: Construct): boolean {
+    let category = EnvironmentContext.getCategory(scope);
+    // return true if category is not undefined
+    return category !== undefined;
+  }
+
   private static isEnvironmentCategoryMatch(scope: Construct, match: EnvironmentCategory): boolean {
     const category = EnvironmentContext.getCategory(scope);
     return category === match;
   }
+
 
 }

--- a/src/project/project-context.ts
+++ b/src/project/project-context.ts
@@ -1,6 +1,7 @@
 import { Construct } from 'constructs';
 import { get } from 'lodash';
 import { addError } from '../error';
+import { AccountWrapper } from '../wrapper';
 import { AccountType } from './account-type';
 import { EnvironmentType } from './environment-type';
 import { Account } from './interfaces';
@@ -62,6 +63,9 @@ export class ProjectContext {
   }
 
   static tryGetEnvironment(scope: Construct): string | undefined {
+    if (scope instanceof AccountWrapper) {
+      return undefined;
+    }
     return EnvironmentType.tryGet(scope);
   }
 

--- a/src/wrapper/environment.ts
+++ b/src/wrapper/environment.ts
@@ -7,6 +7,9 @@ import { EnvironmentContext } from '../context/environment';
  */
 export class EnvironmentWrapper extends Construct {
   constructor(scope: Construct) {
+    if (EnvironmentContext.isValid(scope) !== true) {
+      throw new Error('EnvironmentWrapper requires a valid environment to be defined. Provided environment is [' + scope.node.tryGetContext('environment') + ']');
+    }
     const type = EnvironmentContext.getName(scope);
     const id = `${pascalCase(type)}Environment`;
     super(scope, id);

--- a/test/project/project-context.test.ts
+++ b/test/project/project-context.test.ts
@@ -1,0 +1,99 @@
+import {
+  AccountStrategy,
+  AccountWrapper,
+  EnvironmentContext,
+  EnvironmentWrapper,
+  Project,
+  ProjectContext,
+  ProjectProps,
+} from '../../src';
+
+const projectProps: ProjectProps = {
+  name: 'test-project',
+  author: {
+    organization: 'Acme',
+    name: 'Test Author',
+    email: 'test@example.com',
+  },
+  accounts: AccountStrategy.one({
+    shared: {
+      id: '123456789012',
+    },
+  }),
+};
+
+describe('ProjectContext', () => {
+
+  test('Environment should be undefined in AccountWrapper scope when environment not specified in context', () => {
+    let accountWrapper = new AccountWrapper(new Project({
+      ...projectProps,
+      context: {
+        account: 'shared',
+      },
+    }));
+    expect(accountWrapper.node.tryGetContext('environment')).toBeUndefined();
+    expect(ProjectContext.tryGetEnvironment(accountWrapper)).toBeUndefined();
+  });
+
+  test('Environment should be undefined in AccountWrapper scope even when environment is specified in context', () => {
+    let accountWrapper = new AccountWrapper(new Project({
+      ...projectProps,
+      context: {
+        account: 'shared',
+        environment: 'development',
+      },
+    }));
+    expect(ProjectContext.tryGetEnvironment(accountWrapper)).toBeUndefined();
+  });
+
+  test('AccountWrapper.node.tryGetContext for environment variables returns the environment from AccountWrapper parent scope when environment is specified in context', () => {
+    let accountWrapper = new AccountWrapper(new Project({
+      ...projectProps,
+      context: {
+        account: 'shared',
+        environment: 'development',
+      },
+    }));
+    expect(accountWrapper.node.tryGetContext('environment-type')).toBeUndefined();
+    expect(accountWrapper.node.tryGetContext('env')).toBeUndefined();
+    // Constructs tryGetContext implementation is such that it gets the value from "super" scope, which is Project int this case
+    // tryGetContext(key) {
+    //         const value = this._context[key];
+    //         if (value !== undefined) {
+    //             return value;
+    //         }
+    //         return this.scope && this.scope.node.tryGetContext(key);
+    //     }
+    expect(accountWrapper.node.tryGetContext('environment')).toEqual('development');
+  });
+
+  test('An error should be thrown when environment not specified in context provided to EnvironmentWrapper', () => {
+    try {
+      let environmentWrapper = new EnvironmentWrapper(new Project({
+        ...projectProps,
+        context: {
+          account: 'shared',
+        },
+      }));
+      let environmentCategory = EnvironmentContext.getCategory(environmentWrapper);
+      expect(environmentCategory).toBeUndefined();
+      ProjectContext.tryGetEnvironment(environmentWrapper);
+      throw new Error('Should have failed already');
+    } catch (error) {
+      expect(error).toBeInstanceOf(Error);
+      expect(error).toHaveProperty('message', 'EnvironmentWrapper requires a valid environment to be defined. Provided environment is [undefined]');
+    }
+  });
+
+  test('Environment should be defined in EnvironmentWrapper scope when environment is specified in context', () => {
+    let environmentWrapper = new EnvironmentWrapper(new Project({
+      ...projectProps,
+      context: {
+        account: 'shared',
+        environment: 'development',
+      },
+    }));
+    expect(environmentWrapper.node.tryGetContext('environment')).toEqual('development');
+    expect(ProjectContext.tryGetEnvironment(environmentWrapper)).toEqual('development');
+  });
+});

--- a/test/wrapper/account.test.ts
+++ b/test/wrapper/account.test.ts
@@ -56,7 +56,7 @@ describe('Account stack initialized in context specifying account and environmen
     stack = new SmartStack(account, 'TestStack', { description: 'Test stack' });
   });
 
-  test('Stack name is account wide', () => {
+  test('Stack name is account wide even in environment context', () => {
     expect(stack.stackName).toBe('TestProject-Account-TestStack');
   });
 });

--- a/test/wrapper/account.test.ts
+++ b/test/wrapper/account.test.ts
@@ -1,0 +1,62 @@
+import { Construct } from 'constructs';
+import { AccountStrategy, AccountWrapper, Project, ProjectProps, SmartStack } from '../../src';
+
+const projectProps: ProjectProps = {
+  name: 'test-project',
+  author: {
+    organization: 'Acme',
+    name: 'Test Author',
+    email: 'test@example.com',
+  },
+  accounts: AccountStrategy.one({
+    shared: {
+      id: '123456789012',
+    },
+  }),
+};
+
+export class MockAccount extends AccountWrapper {
+
+  constructor(scope: Construct) {
+    super(scope);
+  }
+};
+
+describe('Account stack initialized in context specifying only account', () => {
+  let stack: SmartStack;
+
+  beforeAll(() => {
+    const project = new Project({
+      ...projectProps,
+      context: {
+        account: 'shared',
+      },
+    });
+    const account = new MockAccount(project);
+    stack = new SmartStack(account, 'TestStack', { description: 'Test stack' });
+  });
+
+  test('Stack name is account wide', () => {
+    expect(stack.stackName).toBe('TestProject-Account-TestStack');
+  });
+});
+
+describe('Account stack initialized in context specifying account and environment', () => {
+  let stack: SmartStack;
+
+  beforeAll(() => {
+    const project = new Project({
+      ...projectProps,
+      context: {
+        account: 'shared',
+        environment: 'development',
+      },
+    });
+    const account = new MockAccount(project);
+    stack = new SmartStack(account, 'TestStack', { description: 'Test stack' });
+  });
+
+  test('Stack name is account wide', () => {
+    expect(stack.stackName).toBe('TestProject-Account-TestStack');
+  });
+});

--- a/test/wrapper/environment.test.ts
+++ b/test/wrapper/environment.test.ts
@@ -1,0 +1,62 @@
+import { AccountStrategy, EnvironmentWrapper, Project, ProjectContext, ProjectProps } from '../../src';
+
+const projectProps: ProjectProps = {
+  name: 'test-project',
+  author: {
+    organization: 'Acme',
+    name: 'Test Author',
+    email: 'test@example.com',
+  },
+  accounts: AccountStrategy.one({
+    shared: {
+      id: '123456789012',
+    },
+  }),
+};
+
+describe('EnvironmentWrapper', () => {
+
+
+  test('An error should be thrown when environment not specified in context provided to EnvironmentWrapper', () => {
+    try {
+      new EnvironmentWrapper(new Project({
+        ...projectProps,
+        context: {
+          account: 'shared',
+        },
+      }));
+      throw new Error('Should have failed already');
+    } catch (error) {
+      expect(error).toBeInstanceOf(Error);
+      expect(error).toHaveProperty('message', 'EnvironmentWrapper requires a valid environment to be defined. Provided environment is [undefined]');
+    }
+  });
+
+  test('An error should be thrown when an invalid environment name is specified in context provided to EnvironmentWrapper', () => {
+    try {
+      new EnvironmentWrapper(new Project({
+        ...projectProps,
+        context: {
+          account: 'shared',
+          environment: 'dilledong',
+        },
+      }));
+      throw new Error('Should have failed already');
+    } catch (error) {
+      expect(error).toBeInstanceOf(Error);
+      expect(error).toHaveProperty('message', 'EnvironmentWrapper requires a valid environment to be defined. Provided environment is [dilledong]');
+    }
+  });
+
+  test('EnvironmentWrapper is successfully initialized when a valid environment name is specified', () => {
+    let environmentWrapper = new EnvironmentWrapper(new Project({
+      ...projectProps,
+      context: {
+        account: 'shared',
+        environment: 'development',
+      },
+    }));
+    expect(environmentWrapper.node.tryGetContext('environment')).toEqual('development');
+    expect(ProjectContext.tryGetEnvironment(environmentWrapper)).toEqual('development');
+  });
+});


### PR DESCRIPTION
- EnvironmentContext.isValid method added to validate provided environment name is allowed
- ProjectContect.tryGetEnvironment modified to return undefined if in the scope of AccountWrapper
- EnvironmentWrapper modified to throw an error if passed scope specifies an invalid environment (undefined or name does not match accepted patterns)
- Tests added to cover these cases
- npm run test passes
- npm run eslint passes
- npm run build passes and updated API.md