### PR TITLE
fix: compatiblity mode for v0 tagging behavior

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -107,6 +107,9 @@ new TextFile(project, 'sonar-project.properties', {
     'sonar.sources=./src',
     'sonar.tests=./test',
     'sonar.test.inclusions=**/*.test.*',
+    "sonar.issue.ignore.multicriteria=e1",
+    "sonar.issue.ignore.multicriteria.e1.ruleKey=typescript:S1874",
+    "sonar.issue.ignore.multicriteria.e1.resourceKey=src/smartstack/tags/*.ts",
   ],
 });
 

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -107,9 +107,9 @@ new TextFile(project, 'sonar-project.properties', {
     'sonar.sources=./src',
     'sonar.tests=./test',
     'sonar.test.inclusions=**/*.test.*',
-    "sonar.issue.ignore.multicriteria=e1",
-    "sonar.issue.ignore.multicriteria.e1.ruleKey=typescript:S1874",
-    "sonar.issue.ignore.multicriteria.e1.resourceKey=src/smartstack/tags/*.ts",
+    'sonar.issue.ignore.multicriteria=e1',
+    'sonar.issue.ignore.multicriteria.e1.ruleKey=typescript:S1874',
+    'sonar.issue.ignore.multicriteria.e1.resourceKey=src/smartstack/tags/*.ts',
   ],
 });
 

--- a/README.md
+++ b/README.md
@@ -210,3 +210,21 @@ Generally speaking you would be most interested in the following:
 - AccountContext (AC)
 - EnvironmentContext (EC)
 - Name / UrlName / PathName
+
+## Migration
+
+### v0 to v1
+
+#### Tagging behavior
+
+Due to a bug in `v0`, the `Contact` and `Organization` tags were NOT applied as they should have. This means that by default, upgrading from v0→v1 introduces CloudFormation diff. Basically adding the `Contact` and `Organization` tags to all resources. This should be safe operation, but we allow disabling it via a feature flag (note that `Contact` and `Organization` tags will most likely be enforced in future `v2`).
+
+```diff
+// cdk.json
+{
+  "context": {
+    // existing context keys
++   "@alma-cdk/project:compatibility:v0:tags": true
+  },
+}
+```

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,3 +5,6 @@ sonar.javascript.lcov.reportPaths=./coverage/lcov.info
 sonar.sources=./src
 sonar.tests=./test
 sonar.test.inclusions=**/*.test.*
+sonar.issue.ignore.multicriteria=e1
+sonar.issue.ignore.multicriteria.e1.ruleKey=typescript:S1874
+sonar.issue.ignore.multicriteria.e1.resourceKey=src/smartstack/tags/*.ts

--- a/src/smartstack/tags/checks.test.ts
+++ b/src/smartstack/tags/checks.test.ts
@@ -1,32 +1,32 @@
-import { useCompatibilityV0Tags, useLegacyTags } from "./checks";
-import { TestableResource } from "./test-helpers/TestableResource";
+import { useCompatibilityV0Tags, useLegacyTags } from './checks';
+import { TestableResource } from './test-helpers/TestableResource';
 
-describe("useLegacyTags", () => {
-  test("returns false if the context key is not set", () => {
+describe('useLegacyTags', () => {
+  test('returns false if the context key is not set', () => {
     const scope = new TestableResource();
     expect(useLegacyTags(scope)).toBe(false);
   });
 
-  test("returns true if the context key is set", () => {
+  test('returns true if the context key is set', () => {
     const scope = new TestableResource({
       context: {
-        "@alma-cdk/project:legacyTags": true,
+        '@alma-cdk/project:legacyTags': true,
       },
     });
     expect(useLegacyTags(scope)).toBe(true);
   });
 });
 
-describe("useCompatibilityV0Tags", () => {
-  test("returns false if the context key is not set", () => {
+describe('useCompatibilityV0Tags', () => {
+  test('returns false if the context key is not set', () => {
     const scope = new TestableResource();
     expect(useCompatibilityV0Tags(scope)).toBe(false);
   });
 
-  test("returns true if the context key is set", () => {
+  test('returns true if the context key is set', () => {
     const scope = new TestableResource({
       context: {
-        "@alma-cdk/project:compatibility:v0:tags": true,
+        '@alma-cdk/project:compatibility:v0:tags': true,
       },
     });
     expect(useCompatibilityV0Tags(scope)).toBe(true);

--- a/src/smartstack/tags/checks.test.ts
+++ b/src/smartstack/tags/checks.test.ts
@@ -1,0 +1,34 @@
+import { useCompatibilityV0Tags, useLegacyTags } from "./checks";
+import { TestableResource } from "./test-helpers/TestableResource";
+
+describe("useLegacyTags", () => {
+  test("returns false if the context key is not set", () => {
+    const scope = new TestableResource();
+    expect(useLegacyTags(scope)).toBe(false);
+  });
+
+  test("returns true if the context key is set", () => {
+    const scope = new TestableResource({
+      context: {
+        "@alma-cdk/project:legacyTags": true,
+      },
+    });
+    expect(useLegacyTags(scope)).toBe(true);
+  });
+});
+
+describe("useCompatibilityV0Tags", () => {
+  test("returns false if the context key is not set", () => {
+    const scope = new TestableResource();
+    expect(useCompatibilityV0Tags(scope)).toBe(false);
+  });
+
+  test("returns true if the context key is set", () => {
+    const scope = new TestableResource({
+      context: {
+        "@alma-cdk/project:compatibility:v0:tags": true,
+      },
+    });
+    expect(useCompatibilityV0Tags(scope)).toBe(true);
+  });
+});

--- a/src/smartstack/tags/checks.ts
+++ b/src/smartstack/tags/checks.ts
@@ -26,6 +26,8 @@ export function useLegacyTags(scope: Construct): boolean {
  * Due to a bug in v0, the `Contact` and `Organization` tags were NOT applied as they should have.
  * This flag can be used to enforce behavior that matches v0 implementation:
  * I.e. `Contact` and `Organization` tags are NOT applied.
+ * 
+ * @deprecated This behavior is not encouraged and will be removed in v2.
  */
 export function useCompatibilityV0Tags(scope: Construct): boolean {
   const contextKey = '@alma-cdk/project:compatibility:v0:tags';

--- a/src/smartstack/tags/checks.ts
+++ b/src/smartstack/tags/checks.ts
@@ -13,7 +13,7 @@ export function hasEnvironment(values: Values): boolean {
 /**
  * Enforces usage of https://github.com/almamedia/alma-cdk-jsii-tag-and-name
  * (for AWS CDK v1) compatible tagging behavior.
- * 
+ *
  * @deprecated This behavior is not encouraged and will be removed in v2. Additionally according to GitHub search, this is not used anymore.
  */
 export function useLegacyTags(scope: Construct): boolean {
@@ -26,7 +26,7 @@ export function useLegacyTags(scope: Construct): boolean {
  * Due to a bug in v0, the `Contact` and `Organization` tags were NOT applied as they should have.
  * This flag can be used to enforce behavior that matches v0 implementation:
  * I.e. `Contact` and `Organization` tags are NOT applied.
- * 
+ *
  * @deprecated This behavior is not encouraged and will be removed in v2.
  */
 export function useCompatibilityV0Tags(scope: Construct): boolean {

--- a/src/smartstack/tags/checks.ts
+++ b/src/smartstack/tags/checks.ts
@@ -10,7 +10,24 @@ export function hasEnvironment(values: Values): boolean {
   return isNonEmptyString(values.environmentType);
 }
 
+/**
+ * Enforces usage of https://github.com/almamedia/alma-cdk-jsii-tag-and-name
+ * (for AWS CDK v1) compatible tagging behavior.
+ * 
+ * @deprecated This behavior is not encouraged and will be removed in v2. Additionally according to GitHub search, this is not used anymore.
+ */
 export function useLegacyTags(scope: Construct): boolean {
   const contextKey = '@alma-cdk/project:legacyTags';
+  return scope.node.tryGetContext(contextKey) === true;
+}
+
+/**
+ * Compatibility flag for v0 tagging behavior.
+ * Due to a bug in v0, the `Contact` and `Organization` tags were NOT applied as they should have.
+ * This flag can be used to enforce behavior that matches v0 implementation:
+ * I.e. `Contact` and `Organization` tags are NOT applied.
+ */
+export function useCompatibilityV0Tags(scope: Construct): boolean {
+  const contextKey = '@alma-cdk/project:compatibility:v0:tags';
   return scope.node.tryGetContext(contextKey) === true;
 }

--- a/src/smartstack/tags/taggers.test.ts
+++ b/src/smartstack/tags/taggers.test.ts
@@ -1,0 +1,311 @@
+import * as cdk from "aws-cdk-lib";
+import {
+  tagAccount,
+  tagEnvironment,
+  tagProject,
+  tagAuthorName,
+  tagAuthorOrganization,
+  tagAuthorEmail,
+} from "./taggers";
+import { TestableResource } from "./test-helpers/TestableResource";
+import { Match } from "aws-cdk-lib/assertions";
+
+describe("tagAccount", () => {
+  test("no account", () => {
+    const testable = new TestableResource();
+
+    tagAccount(testable, cdk.Tags.of(testable), {
+      accountType: "", // empty string is considered "no account"
+      projectName: "",
+      authorName: "",
+    });
+
+    testable.hasProperties({
+      Tags: Match.absent(),
+    });
+  });
+
+  test("account specified", () => {
+    const testable = new TestableResource();
+
+    tagAccount(testable, cdk.Tags.of(testable), {
+      accountType: "test",
+      projectName: "",
+      authorName: "",
+    });
+
+    testable.hasProperties({
+      Tags: [
+        {
+          Key: "Account",
+          Value: "test",
+        },
+      ],
+    });
+  });
+});
+
+describe("tagEnvironment", () => {
+  test("no environment", () => {
+    const testable = new TestableResource();
+
+    tagEnvironment(testable, cdk.Tags.of(testable), {
+      environmentType: "", // empty string is considered "no environment"
+      projectName: "",
+      authorName: "",
+    });
+
+    testable.hasProperties({
+      Tags: Match.absent(),
+    });
+  });
+
+  test("environment specified", () => {
+    const testable = new TestableResource();
+
+    tagEnvironment(testable, cdk.Tags.of(testable), {
+      environmentType: "test",
+      projectName: "",
+      authorName: "",
+    });
+
+    testable.hasProperties({
+      Tags: [
+        {
+          Key: "Environment",
+          Value: "test",
+        },
+      ],
+    });
+  });
+
+  test("legacy mode adds also ProjectAndEnvironment tag", () => {
+    const testable = new TestableResource({
+      context: {
+        "@alma-cdk/project:legacyTags": true,
+      },
+    });
+
+    tagEnvironment(testable, cdk.Tags.of(testable), {
+      environmentType: "test",
+      projectName: "my-project",
+      authorName: "",
+    });
+
+    testable.hasProperties({
+      Tags: [
+        {
+          Key: "Environment",
+          Value: "test",
+        },
+        {
+          Key: "ProjectAndEnvironment",
+          Value: "MyProjectTest",
+        },
+      ],
+    });
+  });
+});
+
+describe("tagProject", () => {
+  test("no project", () => {
+    const testable = new TestableResource();
+
+    tagProject(testable, cdk.Tags.of(testable), {
+      projectName: "",
+      authorName: "",
+    });
+
+    testable.hasProperties({
+      Tags: [
+        {
+          Key: "Project",
+          Value: "", // existing behavior accepts empty string for Project
+        },
+      ],
+    });
+  });
+
+  test("project specified", () => {
+    const testable = new TestableResource();
+
+    tagProject(testable, cdk.Tags.of(testable), {
+      projectName: "my-project",
+      authorName: "",
+    });
+
+    testable.hasProperties({
+      Tags: [
+        {
+          Key: "Project",
+          Value: "my-project",
+        },
+      ],
+    });
+  });
+
+  test("legacy mode converts to Capital Case", () => {
+    const testable = new TestableResource({
+      context: {
+        "@alma-cdk/project:legacyTags": true,
+      },
+    });
+
+    tagProject(testable, cdk.Tags.of(testable), {
+      projectName: "my-project",
+      authorName: "",
+    });
+
+    testable.hasProperties({
+      Tags: [
+        {
+          Key: "Project",
+          Value: "My Project",
+        },
+      ],
+    });
+  });
+});
+
+test("tagAuthorName", () => {
+  const testable = new TestableResource();
+
+  tagAuthorName(testable, cdk.Tags.of(testable), {
+    authorName: "test",
+    projectName: "",
+    authorEmail: "",
+  });
+
+  testable.hasProperties({
+    Tags: [
+      {
+        Key: "Author",
+        Value: "test",
+      },
+    ],
+  });
+});
+
+describe("tagAuthorOrganization", () => {
+  test("compatibility mode not set", () => {
+    const testable = new TestableResource();
+
+    tagAuthorOrganization(testable, cdk.Tags.of(testable), {
+      authorOrganization: "test",
+      projectName: "",
+      authorName: "",
+    });
+
+    testable.hasProperties({
+      Tags: [
+        {
+          Key: "Organization",
+          Value: "test",
+        },
+      ],
+    });
+  });
+
+  test("compatibility mode is set but disabled", () => {
+    const testable = new TestableResource({
+      context: {
+        "@alma-cdk/project:compatibility:v0:tags": false,
+      },
+    });
+
+    tagAuthorOrganization(testable, cdk.Tags.of(testable), {
+      authorOrganization: "test",
+      projectName: "",
+      authorName: "",
+    });
+
+    testable.hasProperties({
+      Tags: [
+        {
+          Key: "Organization",
+          Value: "test",
+        },
+      ],
+    });
+  });
+
+  test("compatibility mode is set", () => {
+    const testable = new TestableResource({
+      context: {
+        "@alma-cdk/project:compatibility:v0:tags": true,
+      },
+    });
+
+    tagAuthorOrganization(testable, cdk.Tags.of(testable), {
+      authorOrganization: "test",
+      projectName: "",
+      authorName: "",
+    });
+
+    testable.hasProperties({
+      Tags: Match.absent(),
+    });
+  });
+});
+
+describe("tagAuthorEmail", () => {
+  test("compatibility mode not set", () => {
+    const testable = new TestableResource();
+
+    tagAuthorEmail(testable, cdk.Tags.of(testable), {
+      authorEmail: "test@example.com",
+      projectName: "",
+      authorName: "",
+    });
+
+    testable.hasProperties({
+      Tags: [
+        {
+          Key: "Contact",
+          Value: "test@example.com",
+        },
+      ],
+    });
+  });
+
+  test("compatibility mode is set but disabled", () => {
+    const testable = new TestableResource({
+      context: {
+        "@alma-cdk/project:compatibility:v0:tags": false,
+      },
+    });
+
+    tagAuthorEmail(testable, cdk.Tags.of(testable), {
+      authorEmail: "test@example.com",
+      projectName: "",
+      authorName: "",
+    });
+
+    testable.hasProperties({
+      Tags: [
+        {
+          Key: "Contact",
+          Value: "test@example.com",
+        },
+      ],
+    });
+  });
+
+  test("compatibility mode is set", () => {
+    const testable = new TestableResource({
+      context: {
+        "@alma-cdk/project:compatibility:v0:tags": true,
+      },
+    });
+
+    tagAuthorEmail(testable, cdk.Tags.of(testable), {
+      authorEmail: "test@example.com",
+      projectName: "",
+      authorName: "",
+    });
+
+    testable.hasProperties({
+      Tags: Match.absent(),
+    });
+  });
+});

--- a/src/smartstack/tags/taggers.test.ts
+++ b/src/smartstack/tags/taggers.test.ts
@@ -1,4 +1,5 @@
-import * as cdk from "aws-cdk-lib";
+import * as cdk from 'aws-cdk-lib';
+import { Match } from 'aws-cdk-lib/assertions';
 import {
   tagAccount,
   tagEnvironment,
@@ -6,18 +7,17 @@ import {
   tagAuthorName,
   tagAuthorOrganization,
   tagAuthorEmail,
-} from "./taggers";
-import { TestableResource } from "./test-helpers/TestableResource";
-import { Match } from "aws-cdk-lib/assertions";
+} from './taggers';
+import { TestableResource } from './test-helpers/TestableResource';
 
-describe("tagAccount", () => {
-  test("no account", () => {
+describe('tagAccount', () => {
+  test('no account', () => {
     const testable = new TestableResource();
 
     tagAccount(testable, cdk.Tags.of(testable), {
-      accountType: "", // empty string is considered "no account"
-      projectName: "",
-      authorName: "",
+      accountType: '', // empty string is considered "no account"
+      projectName: '',
+      authorName: '',
     });
 
     testable.hasProperties({
@@ -25,34 +25,34 @@ describe("tagAccount", () => {
     });
   });
 
-  test("account specified", () => {
+  test('account specified', () => {
     const testable = new TestableResource();
 
     tagAccount(testable, cdk.Tags.of(testable), {
-      accountType: "test",
-      projectName: "",
-      authorName: "",
+      accountType: 'test',
+      projectName: '',
+      authorName: '',
     });
 
     testable.hasProperties({
       Tags: [
         {
-          Key: "Account",
-          Value: "test",
+          Key: 'Account',
+          Value: 'test',
         },
       ],
     });
   });
 });
 
-describe("tagEnvironment", () => {
-  test("no environment", () => {
+describe('tagEnvironment', () => {
+  test('no environment', () => {
     const testable = new TestableResource();
 
     tagEnvironment(testable, cdk.Tags.of(testable), {
-      environmentType: "", // empty string is considered "no environment"
-      projectName: "",
-      authorName: "",
+      environmentType: '', // empty string is considered "no environment"
+      projectName: '',
+      authorName: '',
     });
 
     testable.hasProperties({
@@ -60,186 +60,186 @@ describe("tagEnvironment", () => {
     });
   });
 
-  test("environment specified", () => {
+  test('environment specified', () => {
     const testable = new TestableResource();
 
     tagEnvironment(testable, cdk.Tags.of(testable), {
-      environmentType: "test",
-      projectName: "",
-      authorName: "",
+      environmentType: 'test',
+      projectName: '',
+      authorName: '',
     });
 
     testable.hasProperties({
       Tags: [
         {
-          Key: "Environment",
-          Value: "test",
+          Key: 'Environment',
+          Value: 'test',
         },
       ],
     });
   });
 
-  test("legacy mode adds also ProjectAndEnvironment tag", () => {
+  test('legacy mode adds also ProjectAndEnvironment tag', () => {
     const testable = new TestableResource({
       context: {
-        "@alma-cdk/project:legacyTags": true,
+        '@alma-cdk/project:legacyTags': true,
       },
     });
 
     tagEnvironment(testable, cdk.Tags.of(testable), {
-      environmentType: "test",
-      projectName: "my-project",
-      authorName: "",
+      environmentType: 'test',
+      projectName: 'my-project',
+      authorName: '',
     });
 
     testable.hasProperties({
       Tags: [
         {
-          Key: "Environment",
-          Value: "test",
+          Key: 'Environment',
+          Value: 'test',
         },
         {
-          Key: "ProjectAndEnvironment",
-          Value: "MyProjectTest",
+          Key: 'ProjectAndEnvironment',
+          Value: 'MyProjectTest',
         },
       ],
     });
   });
 });
 
-describe("tagProject", () => {
-  test("no project", () => {
+describe('tagProject', () => {
+  test('no project', () => {
     const testable = new TestableResource();
 
     tagProject(testable, cdk.Tags.of(testable), {
-      projectName: "",
-      authorName: "",
+      projectName: '',
+      authorName: '',
     });
 
     testable.hasProperties({
       Tags: [
         {
-          Key: "Project",
-          Value: "", // existing behavior accepts empty string for Project
+          Key: 'Project',
+          Value: '', // existing behavior accepts empty string for Project
         },
       ],
     });
   });
 
-  test("project specified", () => {
+  test('project specified', () => {
     const testable = new TestableResource();
 
     tagProject(testable, cdk.Tags.of(testable), {
-      projectName: "my-project",
-      authorName: "",
+      projectName: 'my-project',
+      authorName: '',
     });
 
     testable.hasProperties({
       Tags: [
         {
-          Key: "Project",
-          Value: "my-project",
+          Key: 'Project',
+          Value: 'my-project',
         },
       ],
     });
   });
 
-  test("legacy mode converts to Capital Case", () => {
+  test('legacy mode converts to Capital Case', () => {
     const testable = new TestableResource({
       context: {
-        "@alma-cdk/project:legacyTags": true,
+        '@alma-cdk/project:legacyTags': true,
       },
     });
 
     tagProject(testable, cdk.Tags.of(testable), {
-      projectName: "my-project",
-      authorName: "",
+      projectName: 'my-project',
+      authorName: '',
     });
 
     testable.hasProperties({
       Tags: [
         {
-          Key: "Project",
-          Value: "My Project",
+          Key: 'Project',
+          Value: 'My Project',
         },
       ],
     });
   });
 });
 
-test("tagAuthorName", () => {
+test('tagAuthorName', () => {
   const testable = new TestableResource();
 
   tagAuthorName(testable, cdk.Tags.of(testable), {
-    authorName: "test",
-    projectName: "",
-    authorEmail: "",
+    authorName: 'test',
+    projectName: '',
+    authorEmail: '',
   });
 
   testable.hasProperties({
     Tags: [
       {
-        Key: "Author",
-        Value: "test",
+        Key: 'Author',
+        Value: 'test',
       },
     ],
   });
 });
 
-describe("tagAuthorOrganization", () => {
-  test("compatibility mode not set", () => {
+describe('tagAuthorOrganization', () => {
+  test('compatibility mode not set', () => {
     const testable = new TestableResource();
 
     tagAuthorOrganization(testable, cdk.Tags.of(testable), {
-      authorOrganization: "test",
-      projectName: "",
-      authorName: "",
+      authorOrganization: 'test',
+      projectName: '',
+      authorName: '',
     });
 
     testable.hasProperties({
       Tags: [
         {
-          Key: "Organization",
-          Value: "test",
+          Key: 'Organization',
+          Value: 'test',
         },
       ],
     });
   });
 
-  test("compatibility mode is set but disabled", () => {
+  test('compatibility mode is set but disabled', () => {
     const testable = new TestableResource({
       context: {
-        "@alma-cdk/project:compatibility:v0:tags": false,
+        '@alma-cdk/project:compatibility:v0:tags': false,
       },
     });
 
     tagAuthorOrganization(testable, cdk.Tags.of(testable), {
-      authorOrganization: "test",
-      projectName: "",
-      authorName: "",
+      authorOrganization: 'test',
+      projectName: '',
+      authorName: '',
     });
 
     testable.hasProperties({
       Tags: [
         {
-          Key: "Organization",
-          Value: "test",
+          Key: 'Organization',
+          Value: 'test',
         },
       ],
     });
   });
 
-  test("compatibility mode is set", () => {
+  test('compatibility mode is set', () => {
     const testable = new TestableResource({
       context: {
-        "@alma-cdk/project:compatibility:v0:tags": true,
+        '@alma-cdk/project:compatibility:v0:tags': true,
       },
     });
 
     tagAuthorOrganization(testable, cdk.Tags.of(testable), {
-      authorOrganization: "test",
-      projectName: "",
-      authorName: "",
+      authorOrganization: 'test',
+      projectName: '',
+      authorName: '',
     });
 
     testable.hasProperties({
@@ -248,60 +248,60 @@ describe("tagAuthorOrganization", () => {
   });
 });
 
-describe("tagAuthorEmail", () => {
-  test("compatibility mode not set", () => {
+describe('tagAuthorEmail', () => {
+  test('compatibility mode not set', () => {
     const testable = new TestableResource();
 
     tagAuthorEmail(testable, cdk.Tags.of(testable), {
-      authorEmail: "test@example.com",
-      projectName: "",
-      authorName: "",
+      authorEmail: 'test@example.com',
+      projectName: '',
+      authorName: '',
     });
 
     testable.hasProperties({
       Tags: [
         {
-          Key: "Contact",
-          Value: "test@example.com",
+          Key: 'Contact',
+          Value: 'test@example.com',
         },
       ],
     });
   });
 
-  test("compatibility mode is set but disabled", () => {
+  test('compatibility mode is set but disabled', () => {
     const testable = new TestableResource({
       context: {
-        "@alma-cdk/project:compatibility:v0:tags": false,
+        '@alma-cdk/project:compatibility:v0:tags': false,
       },
     });
 
     tagAuthorEmail(testable, cdk.Tags.of(testable), {
-      authorEmail: "test@example.com",
-      projectName: "",
-      authorName: "",
+      authorEmail: 'test@example.com',
+      projectName: '',
+      authorName: '',
     });
 
     testable.hasProperties({
       Tags: [
         {
-          Key: "Contact",
-          Value: "test@example.com",
+          Key: 'Contact',
+          Value: 'test@example.com',
         },
       ],
     });
   });
 
-  test("compatibility mode is set", () => {
+  test('compatibility mode is set', () => {
     const testable = new TestableResource({
       context: {
-        "@alma-cdk/project:compatibility:v0:tags": true,
+        '@alma-cdk/project:compatibility:v0:tags': true,
       },
     });
 
     tagAuthorEmail(testable, cdk.Tags.of(testable), {
-      authorEmail: "test@example.com",
-      projectName: "",
-      authorName: "",
+      authorEmail: 'test@example.com',
+      projectName: '',
+      authorName: '',
     });
 
     testable.hasProperties({

--- a/src/smartstack/tags/taggers.ts
+++ b/src/smartstack/tags/taggers.ts
@@ -1,7 +1,7 @@
 import { Tags } from 'aws-cdk-lib';
 import { capitalCase, pascalCase } from 'change-case';
 import { Construct } from 'constructs';
-import { hasAccount, hasEnvironment, useLegacyTags } from './checks';
+import { hasAccount, hasEnvironment, useCompatibilityV0Tags, useLegacyTags } from './checks';
 import { tagKey, Values } from './values';
 import { isNonEmptyString } from '../../utils/isNonEmptyString';
 
@@ -40,14 +40,14 @@ export const tagAuthorName: Tagger = (_: Construct, tags: Tags, values: Values) 
   tags.add(tagKey.AUTHOR_NAME, values.authorName);
 };
 
-export const tagAuthorOrganization: Tagger = (_: Construct, tags: Tags, values: Values) => {
-  if (isNonEmptyString(values.authorOrganization)) {
+export const tagAuthorOrganization: Tagger = (scope: Construct, tags: Tags, values: Values) => {
+  if (!useCompatibilityV0Tags(scope) && isNonEmptyString(values.authorOrganization)) {
     tags.add(tagKey.AUTHOR_ORGANIZATION, values.authorOrganization);
   }
 };
 
-export const tagAuthorEmail: Tagger = (_: Construct, tags: Tags, values: Values) => {
-  if (isNonEmptyString(values.authorEmail)) {
+export const tagAuthorEmail: Tagger = (scope: Construct, tags: Tags, values: Values) => {
+  if (!useCompatibilityV0Tags(scope) && isNonEmptyString(values.authorEmail)) {
     tags.add(tagKey.AUTHOR_EMAIL, values.authorEmail);
   }
 };

--- a/src/smartstack/tags/test-helpers/TestableResource.ts
+++ b/src/smartstack/tags/test-helpers/TestableResource.ts
@@ -1,6 +1,6 @@
-import * as cdk from "aws-cdk-lib";
-import { Construct } from "constructs";
-import { Template } from "aws-cdk-lib/assertions";
+import * as cdk from 'aws-cdk-lib';
+import { Template } from 'aws-cdk-lib/assertions';
+import { Construct } from 'constructs';
 
 interface TestableResourceProps {
   id?: string;
@@ -12,15 +12,15 @@ interface TestableResourceProps {
  * A helper class that allows easier testing.
  */
 export class TestableResource extends cdk.Resource implements cdk.ITaggable {
-  static readonly TYPE = "For::Testing";
+  static readonly TYPE = 'For::Testing';
 
   public readonly tags = new cdk.TagManager(
     cdk.TagType.KEY_VALUE,
-    TestableResource.TYPE
+    TestableResource.TYPE,
   );
 
   constructor(props: TestableResourceProps = {}) {
-    const { id = "TestScope", scope = new cdk.Stack(), context = {} } = props;
+    const { id = 'TestScope', scope = new cdk.Stack(), context = {} } = props;
 
     Object.entries(context).forEach(([key, value]) => {
       scope.node.setContext(key, value);
@@ -28,7 +28,7 @@ export class TestableResource extends cdk.Resource implements cdk.ITaggable {
 
     super(scope, id);
 
-    new cdk.CfnResource(this, "Resource", {
+    new cdk.CfnResource(this, 'Resource', {
       type: TestableResource.TYPE,
       properties: {
         Tags: this.tags.renderedTags,

--- a/src/smartstack/tags/test-helpers/TestableResource.ts
+++ b/src/smartstack/tags/test-helpers/TestableResource.ts
@@ -1,0 +1,43 @@
+import * as cdk from "aws-cdk-lib";
+import { Construct } from "constructs";
+import { Template } from "aws-cdk-lib/assertions";
+
+interface TestableResourceProps {
+  id?: string;
+  scope?: Construct;
+  context?: Record<string, unknown>;
+}
+
+/**
+ * A helper class that allows easier testing.
+ */
+export class TestableResource extends cdk.Resource implements cdk.ITaggable {
+  static readonly TYPE = "For::Testing";
+
+  public readonly tags = new cdk.TagManager(
+    cdk.TagType.KEY_VALUE,
+    TestableResource.TYPE
+  );
+
+  constructor(props: TestableResourceProps = {}) {
+    const { id = "TestScope", scope = new cdk.Stack(), context = {} } = props;
+
+    Object.entries(context).forEach(([key, value]) => {
+      scope.node.setContext(key, value);
+    });
+
+    super(scope, id);
+
+    new cdk.CfnResource(this, "Resource", {
+      type: TestableResource.TYPE,
+      properties: {
+        Tags: this.tags.renderedTags,
+      },
+    });
+  }
+
+  public hasProperties(props: Record<string, unknown>) {
+    const template = Template.fromStack(cdk.Stack.of(this));
+    template.hasResourceProperties(TestableResource.TYPE, props);
+  }
+}


### PR DESCRIPTION
The previous`v0` [incorrectly performed the "is value non-empty string" checks](https://github.com/alma-cdk/project/blob/main/src/smartstack/tags/taggers.ts#L43-L53) leading to a bug which caused `Organization` and `Contact` tags to be left out.

This bug was fixed in `beta` branch, but it of course now causes CloudFormation diff:
![Screenshot 2024-11-19 at 14 16 31](https://github.com/user-attachments/assets/e396f70c-421e-4496-8dec-44ca6388b027)


This PR adds `@alma-cdk/project:compatibility:v0:tags` feature flag support that users can enable to avoid the diff.

Long-term the current `beta`-version tagging behavior (without the feature flag) will be default, so the feature flag will be removed in future `v2`. But having the feature flag allows users to control when they want to include the new tags.

Additionally this PR adds several tests, especially for the tagging behavior.

This PR also configures SonarCloud to not complain about use of code with `@deprecated` annotation in certain code paths, because we want to still use that code but by using `@deprecated` to signal that those features will be removed in future major versions.