### PR TITLE
fix: unify feature flag names and warning ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ Due to a bug in `v0`, the `Contact` and `Organization` tags were NOT applied as 
 {
   "context": {
     // existing context keys
-+   "@alma-cdk/project:compatibility:v0:tags": true
++   "@alma-cdk/project:compatibilityV0Tags": true
   },
 }
 ```

--- a/src/feature-flags/v0Tags.test.ts
+++ b/src/feature-flags/v0Tags.test.ts
@@ -3,7 +3,7 @@ import { TestableResource } from "../__test__/TestableResource";
 
 describe("useCompatibilityV0Tags", () => {
   test("context key is correct", () => {
-    expect(V0_TAGS_CONTEXT_KEY).toBe("@alma-cdk/project:compatibility:v0:tags");
+    expect(V0_TAGS_CONTEXT_KEY).toBe("@alma-cdk/project:compatibilityV0Tags");
   });
 
   test("returns false if the context key is not set", () => {
@@ -14,7 +14,7 @@ describe("useCompatibilityV0Tags", () => {
   test("returns true if the context key is set", () => {
     const scope = new TestableResource({
       context: {
-        "@alma-cdk/project:compatibility:v0:tags": true,
+        "@alma-cdk/project:compatibilityV0Tags": true,
       },
     });
     expect(useCompatibilityV0Tags(scope)).toBe(true);

--- a/src/feature-flags/v0Tags.ts
+++ b/src/feature-flags/v0Tags.ts
@@ -1,6 +1,6 @@
 import { Construct } from "constructs";
 
-export const V0_TAGS_CONTEXT_KEY = "@alma-cdk/project:compatibility:v0:tags";
+export const V0_TAGS_CONTEXT_KEY = "@alma-cdk/project:compatibilityV0Tags";
 
 /**
  * Compatibility flag for v0 tagging behavior.

--- a/src/smartstack/stack.test.ts
+++ b/src/smartstack/stack.test.ts
@@ -191,7 +191,7 @@ describe("deprecation warnings", () => {
 
     expectErrorMetadata(
       stack,
-      expect.stringContaining("@alma-cdk/project@v1:compatibility-v0-tags"),
+      expect.stringContaining("@alma-cdk/project:compatibilityV0Tags"),
     );
   });
 

--- a/src/smartstack/stack.test.ts
+++ b/src/smartstack/stack.test.ts
@@ -178,7 +178,7 @@ describe("deprecation warnings", () => {
 
     expectErrorMetadata(
       stack,
-      expect.stringContaining("@alma-cdk/project@v1:legacy-tags"),
+      expect.stringContaining("@alma-cdk/project:legacyTags"),
     );
   });
 

--- a/src/smartstack/stack.ts
+++ b/src/smartstack/stack.ts
@@ -68,7 +68,7 @@ export class SmartStack extends Stack {
 
     if (useCompatibilityV0Tags(this)) {
       Annotations.of(this).addWarningV2(
-        "@alma-cdk/project@v1:compatibility-v0-tags",
+        "@alma-cdk/project:compatibilityV0Tags",
         `Using @alma-cdk/project@v0 construct's tagging behavior via "${V0_TAGS_CONTEXT_KEY}" context key. You should migrate to using the default tagging behavior as this feature flag will be removed in v2.`,
       );
     }

--- a/src/smartstack/stack.ts
+++ b/src/smartstack/stack.ts
@@ -61,7 +61,7 @@ export class SmartStack extends Stack {
 
     if (useLegacyTags(this)) {
       Annotations.of(this).addWarningV2(
-        "@alma-cdk/project@v1:legacy-tags",
+        "@alma-cdk/project:legacyTags",
         `Using @almamedia-cdk/tag-and-name (for AWS CDK v1) construct's legacy tagging behavior via "${LEGACY_TAGS_CONTEXT_KEY}" context key. This is not encouraged and will be removed in v2.`,
       );
     }

--- a/src/smartstack/tags/taggers.test.ts
+++ b/src/smartstack/tags/taggers.test.ts
@@ -209,7 +209,7 @@ describe("tagAuthorOrganization", () => {
   test("compatibility mode is set but disabled", () => {
     const testable = new TestableResource({
       context: {
-        "@alma-cdk/project:compatibility:v0:tags": false,
+        "@alma-cdk/project:compatibilityV0Tags": false,
       },
     });
 
@@ -232,7 +232,7 @@ describe("tagAuthorOrganization", () => {
   test("compatibility mode is set", () => {
     const testable = new TestableResource({
       context: {
-        "@alma-cdk/project:compatibility:v0:tags": true,
+        "@alma-cdk/project:compatibilityV0Tags": true,
       },
     });
 
@@ -271,7 +271,7 @@ describe("tagAuthorEmail", () => {
   test("compatibility mode is set but disabled", () => {
     const testable = new TestableResource({
       context: {
-        "@alma-cdk/project:compatibility:v0:tags": false,
+        "@alma-cdk/project:compatibilityV0Tags": false,
       },
     });
 
@@ -294,7 +294,7 @@ describe("tagAuthorEmail", () => {
   test("compatibility mode is set", () => {
     const testable = new TestableResource({
       context: {
-        "@alma-cdk/project:compatibility:v0:tags": true,
+        "@alma-cdk/project:compatibilityV0Tags": true,
       },
     });
 


### PR DESCRIPTION
To avoid confusion, unify feature flag names & warning IDs and align the naming convention to AWS CDK context keys:

## V0 Tagging behavior

Feature Flag:
```diff
- @alma-cdk/project:compatibility:v0:tags
+ @alma-cdk/project:compatibilityV0Tags
```

Warning ID:
```diff
- @alma-cdk/project@v1:compatibility-v0-tags
+ @alma-cdk/project:compatibilityV0Tags
```

## Legacy Tags

Warning ID:
```diff
- @alma-cdk/project@v1:legacy-tags
+ @alma-cdk/project:legacyTags
```