### PR TITLE
fix: strip underscores from resulting stack names

### DIFF
--- a/src/smartstack/name/index.test.ts
+++ b/src/smartstack/name/index.test.ts
@@ -142,6 +142,21 @@ describe("SmartStack", () => {
           "-" +
           capitalizeFirstLetter("n".repeat(48)),
       },
+      // The very first instance of the pattern "a hyphen followed by a number"
+      // got the hyphen stripped, however every other instance ended up with
+      // the hyphen replaced by an underscore -- underscores are not allowed in
+      // CloudFormation stack names. The code was changes to handle every instance
+      // of the pattern the same way -- stripping the hyphen.
+      {
+        name: "multiple hyphen-followed-by-number sequences do not produce underscores",
+        input: {
+          projectName: "Name-123",
+          accountType: undefined,
+          environmentType: "Type-123",
+          stackId: "Id-123",
+        },
+        expected: "Name123-Environment-Type123-Id123",
+      },
     ].map(runTest);
   });
 });

--- a/src/smartstack/name/index.ts
+++ b/src/smartstack/name/index.ts
@@ -21,7 +21,7 @@ const template = `{#
     #}{#
 
     "MyProject-"
-    #}{{ projectName | pascal | truncate(32, true, "") | append("-") }}{#
+    #}{{ projectName | pascal | stripUnderscore | truncate(32, true, "") | append("-") }}{#
 
     #}{% if environment | notEmpty %}{#
       "Environment-Staging-"
@@ -34,7 +34,7 @@ const template = `{#
     #}{% endif %}{#
 
     "MyStack"
-    #}{{ stackId | pascal | truncate(48, true, "")}}`;
+    #}{{ stackId | pascal | stripUnderscore | truncate(48, true, "")}}`;
 
 interface TemplateProps extends TemplateContext {
   stackId: string;

--- a/src/template/index.ts
+++ b/src/template/index.ts
@@ -8,7 +8,7 @@ env.addFilter("pascal", function (str: string) {
 });
 
 env.addFilter("stripUnderscore", function (str: string) {
-  return str.replace("_", "");
+  return str.replace(/_/g, "");
 });
 
 env.addFilter("notEmpty", function (str: string) {


### PR DESCRIPTION
We have recently discovered that when the passed-in environment (i.e. `--context environment=...`) contains more than one instance of the pattern `-[0-9]` (as in "a hyphen followed by a number"), the current version of `@alma-cdk/project` will (incorrectly) replace the first instance by just the number (stripping the hyphen), but all the other instances get converted to `_[0-9]` (as in "an underscore followed by a number"). An underscore is not an allowed character for a stack name (CDK and CloudFormation will error out).

This fix aims to rectify the situation by stripping all underscores in the environment, but since the project and stack id (also used as inputs for stack names) might suffer from the same thing, they get the same treatment and get all underscores stripped also.

CC @aripalo 