### PR TITLE
feat: use trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,6 +69,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    environment: production
     if: needs.release.outputs.tag_exists != 'true' && needs.release.outputs.latest_commit == github.sha
     steps:
       - uses: actions/setup-node@v5
@@ -93,6 +94,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
+    environment: production
     if: needs.release.outputs.tag_exists != 'true' && needs.release.outputs.latest_commit == github.sha
     steps:
       - uses: actions/setup-node@v5
@@ -125,7 +127,7 @@ jobs:
           NPM_DIST_TAG: latest
           NPM_REGISTRY: registry.npmjs.org
           NPM_CONFIG_PROVENANCE: "true"
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TRUSTED_PUBLISHER: "true"
         run: npx -p publib@latest publib-npm
   release_pypi:
     name: Publish to PyPI
@@ -133,6 +135,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      id-token: write
+    environment: production
     if: needs.release.outputs.tag_exists != 'true' && needs.release.outputs.latest_commit == github.sha
     steps:
       - uses: actions/setup-node@v5
@@ -165,8 +169,7 @@ jobs:
         run: mv .repo/dist dist
       - name: Release
         env:
-          TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
-          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+          PYPI_TRUSTED_PUBLISHER: "true"
         run: npx -p publib@latest publib-pypi
   release_golang:
     name: Publish to GitHub Go Module Repository
@@ -174,6 +177,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    environment: production
     if: needs.release.outputs.tag_exists != 'true' && needs.release.outputs.latest_commit == github.sha
     steps:
       - uses: actions/setup-node@v5

--- a/.github/workflows/sonarcloud-report.yml
+++ b/.github/workflows/sonarcloud-report.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Run tests
         run: npm run test
       - name: SonarCloud Scan
-        uses: SonarSource/sonarcloud-github-action@v2
+        uses: SonarSource/sonarqube-scan-action@7
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/sonarcloud-report.yml
+++ b/.github/workflows/sonarcloud-report.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Run tests
         run: npm run test
       - name: SonarCloud Scan
-        uses: SonarSource/sonarqube-scan-action@7
+        uses: SonarSource/sonarqube-scan-action@v7
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -111,7 +111,7 @@ sonarCloudReportWorkflow?.addJob("sonarcloud-report", {
     },
     {
       name: "SonarCloud Scan",
-      uses: "SonarSource/sonarcloud-github-action@v2",
+      uses: "SonarSource/sonarqube-scan-action@7",
       env: {
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}",
         SONAR_TOKEN: "${{ secrets.SONAR_TOKEN }}",

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -111,7 +111,7 @@ sonarCloudReportWorkflow?.addJob("sonarcloud-report", {
     },
     {
       name: "SonarCloud Scan",
-      uses: "SonarSource/sonarqube-scan-action@7",
+      uses: "SonarSource/sonarqube-scan-action@v7",
       env: {
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}",
         SONAR_TOKEN: "${{ secrets.SONAR_TOKEN }}",

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -47,9 +47,12 @@ const project = new awscdk.AwsCdkConstructLibrary({
   defaultReleaseBranch: "main",
   packageManager: javascript.NodePackageManager.NPM,
   npmAccess: javascript.NpmAccess.PUBLIC,
-  python: {
+  npmTrustedPublishing: true,
+  releaseEnvironment: "production",
+  publishToPypi: {
     distName: "alma-cdk.project",
     module: "alma_cdk.project",
+    trustedPublishing: true,
   },
   publishToGo: {
     moduleName: "github.com/alma-cdk/project-go",


### PR DESCRIPTION
This PR configures Projen to use [Trusted Publishing](https://projen.io/docs/publishing/trusted-publishing) with supported package managers.

In addition to these code changes, configuration changes have been made in GitHub, NPMJS, and PyPi. These changes are documented internally.