### PR TITLE
fix: pass maxLength to super calls in UrlName and PathName

### DIFF
--- a/AlmaCdkConstructLibrary/NodeConfig.ts
+++ b/AlmaCdkConstructLibrary/NodeConfig.ts
@@ -24,7 +24,7 @@ export class NodeConfig {
         nodeLinker: "hoisted", // required for bundled deps
         resolutionMode: "highest",
         strictDepBuilds: true,
-        onlyBuiltDependencies: ["unrs-resolver"],  // allow unrs-resolver build scripts
+        onlyBuiltDependencies: ["unrs-resolver"], // allow unrs-resolver build scripts
         blockExoticSubdeps: true,
         overrides: {
           "ajv@^8": "^8.18.0",

--- a/src/name/max-length.ts
+++ b/src/name/max-length.ts
@@ -26,7 +26,7 @@ export function validateMaxLength(
 ): void {
   if (isTooLong(value, maxLength)) {
     Annotations.of(scope).addError(
-      `Name value "${value}" is longer than the allowed limit of ${maxLength}`,
+      `Name value "${value}" is longer than the allowed limit of ${decideMaxLength(value, maxLength)}`,
     );
   }
 }

--- a/src/name/name-path.test.ts
+++ b/src/name/name-path.test.ts
@@ -131,6 +131,44 @@ describe("PathName resources", () => {
     },
   );
 
+  test.each<[string, (stack: cdk.Stack, name: string) => string]>([
+    [
+      "it",
+      (s, n) =>
+        PathName.it(s, n, { maxLength: MAX_LENGTH_DEFAULT, trim: true }),
+    ],
+    [
+      "withProject",
+      (s, n) =>
+        PathName.withProject(s, n, {
+          maxLength: MAX_LENGTH_DEFAULT,
+          trim: true,
+        }),
+    ],
+    [
+      "globally",
+      (s, n) =>
+        PathName.globally(s, n, { maxLength: MAX_LENGTH_DEFAULT, trim: true }),
+    ],
+  ])(
+    '"%s" with trim:true accepts baseName longer than MAX_LENGTH_DEFAULT and trims it to the correct length',
+    (_methodName, methodCall) => {
+      const project = new Project({
+        ...projectProps,
+        context: { environment: "test" },
+      });
+      const stack = new cdk.Stack(project, "testing-stack");
+
+      const longBaseName = "TenLetters".repeat(
+        Math.ceil(MAX_LENGTH_DEFAULT / 10) + 1,
+      );
+
+      expect(methodCall(stack, longBaseName)).toHaveLength(MAX_LENGTH_DEFAULT);
+      Template.fromStack(stack);
+      Annotations.fromStack(stack).hasNoError("*", Match.anyValue());
+    },
+  );
+
   test("shorthand method", () => {
     const project = new Project({
       ...projectProps,

--- a/src/name/name-path.test.ts
+++ b/src/name/name-path.test.ts
@@ -1,6 +1,8 @@
 import * as cdk from "aws-cdk-lib";
+import { Annotations, Match, Template } from "aws-cdk-lib/assertions";
 import { PathName, pathName } from "./";
 import { Project, ProjectProps } from "../project";
+import { MAX_LENGTH_DEFAULT } from "./max-length";
 
 const projectProps: ProjectProps = {
   name: "test-project",
@@ -97,6 +99,37 @@ describe("PathName resources", () => {
     expect(PathName.globally(stack, "foo.bar")).toBe(expectedBase + "foobar");
     expect(PathName.globally(stack, "foo/bar")).toBe(expectedBase + "foo/bar");
   });
+
+  const longBaseName = "a".repeat(MAX_LENGTH_DEFAULT + 10);
+  const maxLength = MAX_LENGTH_DEFAULT + 100;
+
+  test.each<[string, (stack: cdk.Stack, name: string) => string, string]>([
+    ["it", (s, n) => PathName.it(s, n, { maxLength }), `/test/${longBaseName}`],
+    [
+      "withProject",
+      (s, n) => PathName.withProject(s, n, { maxLength }),
+      `/test/project/test/${longBaseName}`,
+    ],
+    [
+      "globally",
+      (s, n) => PathName.globally(s, n, { maxLength }),
+      `/acme/test/project/test/${longBaseName}`,
+    ],
+  ])(
+    '"%s" accepts baseName longer than MAX_LENGTH_DEFAULT chars when maxLength is higher',
+    (_methodName, methodCall, expected) => {
+      const project = new Project({
+        ...projectProps,
+        context: { environment: "test" },
+      });
+
+      const stack = new cdk.Stack(project, "testing-stack");
+
+      expect(methodCall(stack, longBaseName)).toBe(expected);
+      Template.fromStack(stack);
+      Annotations.fromStack(stack).hasNoError("*", Match.anyValue());
+    },
+  );
 
   test("shorthand method", () => {
     const project = new Project({

--- a/src/name/name-path.ts
+++ b/src/name/name-path.ts
@@ -10,7 +10,7 @@ export abstract class PathName extends UrlName {
     baseName: string,
     props?: NameProps,
   ): string {
-    const result = `/${super.it(scope, "").replace(/-/g, "/")}/${baseName.replace(/[\.\s]/g, "")}`;
+    const result = `/${super.it(scope, "", { maxLength: props?.maxLength }).replace(/-/g, "/")}/${baseName.replace(/[\.\s]/g, "")}`;
     const trimmed = trim(result, baseName, props);
     validateMaxLength(scope, trimmed, props?.maxLength);
     return trimmed;
@@ -20,7 +20,7 @@ export abstract class PathName extends UrlName {
     baseName: string,
     props?: NameProps,
   ): string {
-    const result = `/${super.withProject(scope, "").replace(/-/g, "/")}/${baseName.replace(/[\.\s]/g, "")}`;
+    const result = `/${super.withProject(scope, "", { maxLength: props?.maxLength }).replace(/-/g, "/")}/${baseName.replace(/[\.\s]/g, "")}`;
     const trimmed = trim(result, baseName, props);
     validateMaxLength(scope, trimmed, props?.maxLength);
     return trimmed;
@@ -30,7 +30,7 @@ export abstract class PathName extends UrlName {
     baseName: string,
     props?: NameProps,
   ): string {
-    const result = `/${super.globally(scope, "").replace(/-/g, "/")}/${baseName.replace(/[\.\s]/g, "")}`;
+    const result = `/${super.globally(scope, "", { maxLength: props?.maxLength }).replace(/-/g, "/")}/${baseName.replace(/[\.\s]/g, "")}`;
     const trimmed = trim(result, baseName, props);
     validateMaxLength(scope, trimmed, props?.maxLength);
     return trimmed;

--- a/src/name/name-path.ts
+++ b/src/name/name-path.ts
@@ -10,7 +10,7 @@ export abstract class PathName extends UrlName {
     baseName: string,
     props?: NameProps,
   ): string {
-    const result = `/${super.it(scope, "", { maxLength: props?.maxLength }).replace(/-/g, "/")}/${baseName.replace(/[\.\s]/g, "")}`;
+    const result = `/${super.it(scope, "", props).replace(/-/g, "/")}/${baseName.replace(/[\.\s]/g, "")}`;
     const trimmed = trim(result, baseName, props);
     validateMaxLength(scope, trimmed, props?.maxLength);
     return trimmed;
@@ -20,7 +20,7 @@ export abstract class PathName extends UrlName {
     baseName: string,
     props?: NameProps,
   ): string {
-    const result = `/${super.withProject(scope, "", { maxLength: props?.maxLength }).replace(/-/g, "/")}/${baseName.replace(/[\.\s]/g, "")}`;
+    const result = `/${super.withProject(scope, "", props).replace(/-/g, "/")}/${baseName.replace(/[\.\s]/g, "")}`;
     const trimmed = trim(result, baseName, props);
     validateMaxLength(scope, trimmed, props?.maxLength);
     return trimmed;
@@ -30,7 +30,7 @@ export abstract class PathName extends UrlName {
     baseName: string,
     props?: NameProps,
   ): string {
-    const result = `/${super.globally(scope, "", { maxLength: props?.maxLength }).replace(/-/g, "/")}/${baseName.replace(/[\.\s]/g, "")}`;
+    const result = `/${super.globally(scope, "", props).replace(/-/g, "/")}/${baseName.replace(/[\.\s]/g, "")}`;
     const trimmed = trim(result, baseName, props);
     validateMaxLength(scope, trimmed, props?.maxLength);
     return trimmed;

--- a/src/name/name-url.test.ts
+++ b/src/name/name-url.test.ts
@@ -1,6 +1,8 @@
 import * as cdk from "aws-cdk-lib";
+import { Annotations, Match, Template } from "aws-cdk-lib/assertions";
 import { UrlName, urlName } from ".";
 import { Project, ProjectProps } from "../project";
+import { MAX_LENGTH_DEFAULT } from "./max-length";
 
 const projectProps: ProjectProps = {
   name: "test-project",
@@ -77,6 +79,37 @@ describe("UrlName resources", () => {
     expect(UrlName.globally(stack, "foo bar")).toBe(expected);
     expect(UrlName.globally(stack, "foo.bar")).toBe(expected);
   });
+
+  const longBaseName = "a".repeat(MAX_LENGTH_DEFAULT + 10);
+  const maxLength = MAX_LENGTH_DEFAULT + 100;
+
+  test.each<[string, (stack: cdk.Stack, name: string) => string, string]>([
+    ["it", (s, n) => UrlName.it(s, n, { maxLength }), `test-${longBaseName}`],
+    [
+      "withProject",
+      (s, n) => UrlName.withProject(s, n, { maxLength }),
+      `test-project-test-${longBaseName}`,
+    ],
+    [
+      "globally",
+      (s, n) => UrlName.globally(s, n, { maxLength }),
+      `acme-test-project-test-${longBaseName}`,
+    ],
+  ])(
+    '"%s" accepts baseName longer than MAX_LENGTH_DEFAULT chars when maxLength is higher',
+    (_methodName, methodCall, expected) => {
+      const project = new Project({
+        ...projectProps,
+        context: { environment: "test" },
+      });
+
+      const stack = new cdk.Stack(project, "testing-stack");
+
+      expect(methodCall(stack, longBaseName)).toBe(expected);
+      Template.fromStack(stack);
+      Annotations.fromStack(stack).hasNoError("*", Match.anyValue());
+    },
+  );
 
   test("shorthand method", () => {
     const project = new Project({

--- a/src/name/name-url.test.ts
+++ b/src/name/name-url.test.ts
@@ -111,6 +111,29 @@ describe("UrlName resources", () => {
     },
   );
 
+  test.each<[string, (stack: cdk.Stack, name: string) => string]>([
+    ["it", (s, n) => UrlName.it(s, n, { trim: true })],
+    ["withProject", (s, n) => UrlName.withProject(s, n, { trim: true })],
+    ["globally", (s, n) => UrlName.globally(s, n, { trim: true })],
+  ])(
+    '"%s" with trim:true accepts baseName longer than MAX_LENGTH_DEFAULT and trims it to the correct length',
+    (_methodName, methodCall) => {
+      const project = new Project({
+        ...projectProps,
+        context: { environment: "test" },
+      });
+      const stack = new cdk.Stack(project, "testing-stack");
+
+      const longBaseName = "TenLetters".repeat(
+        Math.ceil(MAX_LENGTH_DEFAULT / 10) + 1,
+      );
+
+      expect(methodCall(stack, longBaseName)).toHaveLength(MAX_LENGTH_DEFAULT);
+      Template.fromStack(stack);
+      Annotations.fromStack(stack).hasNoError("*", Match.anyValue());
+    },
+  );
+
   test("shorthand method", () => {
     const project = new Project({
       ...projectProps,

--- a/src/name/name-url.ts
+++ b/src/name/name-url.ts
@@ -11,9 +11,7 @@ export abstract class UrlName extends Name {
     baseName: string,
     props?: NameProps,
   ): string {
-    const result = paramCase(
-      super.it(scope, baseName, { maxLength: props?.maxLength }),
-    );
+    const result = paramCase(super.it(scope, baseName, props));
     const trimmed = trim(result, baseName, props);
     validateMaxLength(scope, trimmed, props?.maxLength);
     return trimmed;
@@ -23,9 +21,7 @@ export abstract class UrlName extends Name {
     baseName: string,
     props?: NameProps,
   ): string {
-    const result = paramCase(
-      super.withProject(scope, baseName, { maxLength: props?.maxLength }),
-    );
+    const result = paramCase(super.withProject(scope, baseName, props));
     const trimmed = trim(result, baseName, props);
     validateMaxLength(scope, trimmed, props?.maxLength);
     return trimmed;
@@ -35,9 +31,7 @@ export abstract class UrlName extends Name {
     baseName: string,
     props?: NameProps,
   ): string {
-    const result = paramCase(
-      super.globally(scope, baseName, { maxLength: props?.maxLength }),
-    );
+    const result = paramCase(super.globally(scope, baseName, props));
     const trimmed = trim(result, baseName, props);
     validateMaxLength(scope, trimmed, props?.maxLength);
     return trimmed;

--- a/src/name/name-url.ts
+++ b/src/name/name-url.ts
@@ -11,7 +11,9 @@ export abstract class UrlName extends Name {
     baseName: string,
     props?: NameProps,
   ): string {
-    const result = paramCase(super.it(scope, baseName));
+    const result = paramCase(
+      super.it(scope, baseName, { maxLength: props?.maxLength }),
+    );
     const trimmed = trim(result, baseName, props);
     validateMaxLength(scope, trimmed, props?.maxLength);
     return trimmed;
@@ -21,7 +23,9 @@ export abstract class UrlName extends Name {
     baseName: string,
     props?: NameProps,
   ): string {
-    const result = paramCase(super.withProject(scope, baseName));
+    const result = paramCase(
+      super.withProject(scope, baseName, { maxLength: props?.maxLength }),
+    );
     const trimmed = trim(result, baseName, props);
     validateMaxLength(scope, trimmed, props?.maxLength);
     return trimmed;
@@ -31,7 +35,9 @@ export abstract class UrlName extends Name {
     baseName: string,
     props?: NameProps,
   ): string {
-    const result = paramCase(super.globally(scope, baseName));
+    const result = paramCase(
+      super.globally(scope, baseName, { maxLength: props?.maxLength }),
+    );
     const trimmed = trim(result, baseName, props);
     validateMaxLength(scope, trimmed, props?.maxLength);
     return trimmed;


### PR DESCRIPTION
When calling:
```
PathName.withProject(this, 'CronMailSendNewProfileJobDescriptionNotifications', { maxLength: 255 })
```

we were getting error like:
```
Error: at /StagingEnvironment/CronSchedulerStack] Name value "AtmoskopStagingCronMailSendNewProfileJobDescriptionNotifications" is longer than the allowed limit of undefined
```

The problem was that `props?.maxLength` was not passed to the `super.WithProject` call and this parent function then defaulted to `MAX_LENGTH_DEFAULT` (63 characters) when calling `validateMaxLength` instead of using 255 characters as specified by the `maxLength` option.

**Note:** I am not sure if the tests scenarios really make sense. They feel kind of too specific. But maybe to prevent regression?